### PR TITLE
Add GitHub Skills activity to the extracurricular offerings

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -39,6 +39,12 @@ activities = {
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
     },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program.",
+        "schedule": "Mondays, 4:00 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Soccer Team": {
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",


### PR DESCRIPTION
This pull request adds a new club entry to the application data. Specifically, it introduces the "GitHub Skills" club, providing details such as its description, schedule, maximum number of participants, and an empty participants list.

- Data update:
  * Added a new club, `"GitHub Skills"`, with its description, schedule, max participants, and an empty participants list in `src/app.py`.